### PR TITLE
Add `state-switch-buffer-other-window' for utility function.

### DIFF
--- a/state.el
+++ b/state.el
@@ -45,7 +45,7 @@
 (eval-when-compile
   (require 'cl-lib))
 
-;; Compatibility
+;;; Compatibility
 (unless (functionp 'cl-struct-slot-info)
   (defun cl-struct-slot-info (struct-type)
     "Return a list of slot names of struct STRUCT-TYPE.

--- a/state.el
+++ b/state.el
@@ -415,6 +415,13 @@ key after switching. Leave nil is you don't want this feature."
   "Enable State minor mode."
   (state-mode 1))
 
+;;; Utility function
+(defun state-switch-buffer-other-window (buf)
+  "Select window BUF is shown, otherwise display BUF in other window."
+  (if (get-buffer-window buf)
+      (select-window (get-buffer-window buf))
+    (switch-to-buffer-other-window buf)))
+
 (provide 'state)
 
 ;;; state.el ends here


### PR DESCRIPTION
I think :switch sexps in examples in README.md is redundant.

By adding `Utility function' section, add one semicolon to`Compatibility' section.
